### PR TITLE
Add qtcreator to recommends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Architecture: all
 Section: utils
 Depends: ${shlibs:Depends},
          ${misc:Depends}
-Recommends: libnymea1-dev, nymea-dev-tools
+Recommends: libnymea1-dev, nymea-dev-tools, qtcreator
 Description: Qt Creator project template for nymea.io plugins
  The nymea daemon is a plugin based IoT (Internet of Things) server. The
  server works like a translator for devices, things and services and


### PR DESCRIPTION
Intentionally not a dependency because someone might want
to install with --no-recommends and use qtcreator from downloads.qt.io
instead.